### PR TITLE
added credit card bill payment category and logic to exclude the categories

### DIFF
--- a/src/categories/default-categories.service.ts
+++ b/src/categories/default-categories.service.ts
@@ -44,7 +44,7 @@ export class DefaultCategoriesService {
       'Professional Expenses', 'Business Utilities', 'Office Supplies',
 
       // 💸 Personal Finance
-      'Savings', 'Investments', 'Donations', 'Bank Fees'
+      'Savings', 'Investments', 'Donations', 'Bank Fees', 'Credit Card Bill Payment'
     ];
   }
 

--- a/src/categories/entities/category.entity.ts
+++ b/src/categories/entities/category.entity.ts
@@ -22,4 +22,10 @@ export class Category {
 
   @OneToMany(() => RecurringTransaction, (recurringTransaction) => recurringTransaction.category)
   recurringTransactions: RecurringTransaction[];
+
+  @Column({ default: false })
+  excludeFromExpenseAnalytics: boolean;
+
+  @Column({ nullable: true })
+  analyticsExclusionReason: string;
 }


### PR DESCRIPTION
- Default excluded categories out of the box
- User control to customize which categories are excluded
- Flexibility to add more excluded categories in the future
- No hardcoded category names in your analytics code

Dashboard Changes:
   - Updated `getExpenseDistributionByCategory` to exclude marked categories
   - Updated `getMonthlyIncomeAndExpenses` to use SQL filtering for exclusions
   - Updated `getMonthlyStatistics` with separate SQL queries for efficient filtering
   - Updated `getSavingsPlanByCategory` to respect category exclusions
   - Modified cash flow forecasting to use the improved data

   These changes prevent double-counting of expenses when users make credit card payments, resulting in more accurate financial reporting.